### PR TITLE
Support for a filter reducer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ Reductio is a library for generating Crossfilter reduce functions and applying t
 npm install --save-dev reductio
 ```
 
-## Bower 
+## Bower
 ```shell
 bower install --save-dev reductio
 ```
@@ -159,6 +159,45 @@ Will result in groups that look like
   z: { sum: 2 }
 }}
 ```
+
+### reductio.<b>filter</b>(<i>filterFn</i>)
+```javascript
+reductio().filter(filterFn)(group)
+```
+Filters values from being added/removed from groups.  Works well with ```value```
+chains, and is also very useful if you need to aggregate sparsely-populated fields.
+
+```javascript
+var reducer = reductio();
+reducer.value("evens").count(true)
+  .filter(function(d) { return d.bar % 2 === 0}; });
+reducer.value("rare")
+  .filter(function(d) { return typeof d.rareVal === 'undefined' ; })
+  .sum(function(d) return d.rareVal; );
+reducer(group);
+```
+
+For example:
+
+```javascript
+// Given:
+[
+  { foo: 'one', num: 1 },
+  { foo: 'two', num: 2 },
+  { foo: 'three', num: 3, rareVal: 98 },
+  { foo: 'one', num: 3, rareVal: 99 },
+  { foo: 'one', num: 4, rareVal: 100 },
+  { foo: 'two', num: 6 }
+]
+
+// The groups will look like:
+[
+  { key: 'one', value: { evens: { count: 1 }, rare: { sum: 199 } }
+  { key: 'two', value: { evens: { count: 2 }, rare: { sum: 98 } }
+  { key: 'three', value: { evens: { count: 0 }, rare: { sum: 0 } }
+]
+```
+
 
 ### reductio.<b>nest</b>(<i>keyAccessorArray</i>)
 ```javascript

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,9 +3,10 @@ module.exports = function(config) {
     basePath: '.',
 
     frameworks: ['jasmine'],
-    
+
     files: [
 		'node_modules/crossfilter/crossfilter.min.js',
+		'node_modules/lodash/index.js',
 		'reductio.min.js',
 		'test/**/*.spec.js'
     ],

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "karma-firefox-launcher": "^0.1.4",
     "karma-jasmine": "~0.1.0",
     "karma-phantomjs-launcher": "^0.1.4",
+    "lodash": "^3.3.0",
     "vinyl-source-stream": "^1.0.0"
   },
   "scripts": {

--- a/src/accessors.js
+++ b/src/accessors.js
@@ -39,6 +39,12 @@ function accessor_build(obj, p) {
 		return obj;
 	};
 
+	obj.filter = function(value) {
+		if (!arguments.length) return p.filter;
+		p.filter = value;
+		return obj;
+	};
+
 	obj.valueList = function(value) {
 		if (!arguments.length) return p.valueList;
 		p.valueList = value;

--- a/src/filter.js
+++ b/src/filter.js
@@ -1,0 +1,29 @@
+var reductio_filter = {
+	// The big idea here is that you give us a filter function to run on values,
+	// a 'prior' reducer to run (just like the rest of the standard reducers),
+	// and a reference to the last reducer (called 'skip' below) defined before
+	// the most recent chain of reducers.  This supports individual filters for
+	// each .value('...') chain that you add to your reducer.
+	add: function (filter, prior, skip) {
+		return function (p, v) {
+			if (filter(v)) {
+				if (prior) prior(p, v);
+			} else {
+				if (skip) skip(p, v);
+			}
+			return p;
+		};
+	},
+	remove: function (filter, prior, skip) {
+		return function (p, v) {
+			if (filter(v)) {
+				if (prior) prior(p, v);
+			} else {
+				if (skip) skip(p, v);
+			}
+			return p;
+		};
+	}
+};
+
+module.exports = reductio_filter;

--- a/src/parameters.js
+++ b/src/parameters.js
@@ -7,6 +7,7 @@ var reductio_parameters = function() {
 		exceptionAccessor: false,
 		exceptionCount: false,
 		exceptionSum: false,
+		filter: false,
 		valueList: false,
 		median: false,
 		histogramValue: false,

--- a/test/filter.spec.js
+++ b/test/filter.spec.js
@@ -1,0 +1,64 @@
+// Filtering tests
+describe('Reductio filter', function () {
+    var dim;
+
+    beforeEach(function () {
+        var data = crossfilter([
+            { foo: 'one', bar: 1 },
+            { foo: 'two', bar: 2 },
+            { foo: 'three', bar: 3 },
+            { foo: 'one', bar: 4, sparseVal: 5 },
+            { foo: 'one', bar: 5, sparseVal: 15 },
+            { foo: 'two', bar: 6 },
+        ]);
+
+        dim = data.dimension(function(d) { return d.foo; });
+    });
+
+    it('groups a counting reducer', function() {
+      var reducer = reductio().count(true)
+        .filter(function(d) { return d.bar > 3; });
+
+      var map = _.indexBy(reducer(dim.group()).top(Infinity), 'key');
+      expect(map.one.value.count).toEqual(2);
+      expect(map.two.value.count).toEqual(1);
+      expect(map.three.value.count).toEqual(0);
+    });
+
+    it('groups an averaging reducer', function() {
+      var reducer = reductio()
+        .filter(function(d) { return d.bar > 3; })
+        .avg(function (d) { return d.bar; });
+
+      var map = _.indexBy(reducer(dim.group()).top(Infinity), 'key');
+      expect(map.one.value.avg).toBeCloseTo(4.5);
+      expect(map.two.value.avg).toEqual(6);
+      expect(map.three.value.avg).toEqual(0);
+    });
+
+    it('handles value lists', function() {
+      var reducer = reductio();
+      reducer.value("gt3").filter(function(d) { return d.bar > 3; }).count(true);
+      reducer.value("even").filter(function(d) { return d.bar % 2 === 0; }).count(true);
+
+      var map = _.indexBy(reducer(dim.group()).top(Infinity), 'key');
+      expect(map.one.value.gt3.count).toEqual(2);
+      expect(map.one.value.even.count).toEqual(1);
+      expect(map.two.value.gt3.count).toEqual(1);
+      expect(map.two.value.even.count).toEqual(2);
+      expect(map.three.value.gt3.count).toEqual(0);
+      expect(map.three.value.even.count).toEqual(0);
+    });
+
+    it('handles sparsely-populated data', function() {
+      var reducer = reductio()
+        .filter(function(d) { return typeof d.sparseVal !== "undefined"; })
+        .avg(function(d) { return d.sparseVal; });
+
+      var map = _.indexBy(reducer(dim.group()).top(Infinity), 'key');
+      expect(map.one.value.count).toEqual(2);
+      expect(map.one.value.avg).toBeCloseTo(10);
+      expect(map.two.value.count).toEqual(0);
+      expect(map.three.value.count).toEqual(0);
+    });
+});


### PR DESCRIPTION
Adds a prototype filter reducer as suggested on upstream issue #3 

I needed this feature for some tinkering I'm doing - hope I'm not stepping on any toes.

I'm not familiar enough with the deeper features of reductio to understand if this patch will work with everything, but I thought it was a good first shot.  I know it'll work with ```value``` filters.  Are there any tests you can think of that might trip up filtering like this?

I also added lodash as a dev library to help with the unit tests and it looks like my dumb editor added a newline here or there.  Let me know if you'd rather leave those out and I'll do some cleaning.