### PR TITLE
Fix goof in .filter docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -172,7 +172,7 @@ var reducer = reductio();
 reducer.value("evens").count(true)
   .filter(function(d) { return d.bar % 2 === 0}; });
 reducer.value("rare")
-  .filter(function(d) { return typeof d.rareVal === 'undefined' ; })
+  .filter(function(d) { return typeof d.rareVal !== 'undefined' ; })
   .sum(function(d) return d.rareVal; );
 reducer(group);
 ```


### PR DESCRIPTION
Sorry I didn't notice this earlier, but in my haste I put in a `===` when I meant `!==` in the docs for .filter