### PR TITLE
fix browserify issue where package is incorrectly shimmed

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "url": "https://github.com/esjewett/reductio/issues"
   },
   "homepage": "https://github.com/esjewett/reductio",
+  "browser": {
+    "crossfilter": "crossfilter2"
+  },
   "browserify-shim": {
     "crossfilter": "global:crossfilter"
   }


### PR DESCRIPTION
I had trouble updating reductio from 0.3 to 0.5

browserify keeps telling me: 
```
Cannot find module 'crossfilter' from '/home/echo/git/nordfjord/test/node_modules/reductio/src'
```

The reason seems to be that reductio now depends on `crossfilter2` but shims it : `"crossfilter": "global:crossfilter"`

When I then try to bundle reductio in my app it tries to use `require('crossfilter')` but cannot since the dependency is actually to `crossfilter2`.

The problem with using browserify-shim this way is that it is scoped locally, meaning that no matter how I use shimming in my app `crossfilter` will never be found from reductio

This can be fixed using browserify-shim's "browser" field

```json
{
  "browser": {
    "crossfilter": "crossfilter2"
}
```

and that is all this PR does